### PR TITLE
Write to history when site updated

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,25 @@
+name: Upload to KV
+on: 
+  push:
+    branches: [main]
+  paths:
+    - 'pages/index.html'
+jobs:
+  upload-to-kv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get current date
+        id: date
+        run: echo "DATE=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
+      - name: Read HTML file
+        id: content
+        run: echo "html=$(cat pages/index.html)" >> $GITHUB_OUTPUT
+      - name: upload-to-kv
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+        with:
+          namespace_identifier: 'life-history'
+          key_name: ${{ env.DATE }} ${{ github.event.head_commit.message }}
+          value: ${{ steps.content.outputs.html }}


### PR DESCRIPTION
When I commit a change to the site I want that change to be stored in KV so that I can display it in a timeline. I only want this to happen on main and only when changing `pages/index.html`. 

Notes to future me:

- Keys are limited to 512 bytes... I'm formatting it as `${date} ${commit message}` so I should remember to keep the commits short. 
- Values are 25 MiB. Shouldn't make the site any larger than that. It would be good at some point to add a size limit check. 